### PR TITLE
Disable Postgres implicit prepared statements

### DIFF
--- a/internal/datasource/cardano_db_sync/cardano_db_sync.go
+++ b/internal/datasource/cardano_db_sync/cardano_db_sync.go
@@ -35,7 +35,10 @@ func (c *CardanoDbSync) Connect() error {
 		c.cfg.DbName,
 		c.cfg.SslMode,
 	)
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  dsn,
+		PreferSimpleProtocol: true, // disables implicit prepared statement usage
+	}), &gorm.Config{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Disable the implicit use of prepared statements in our Postgres database
connection. This will prevent SQLSTATE 42P05 errors being thrown when
passing through a load balancer or using pgbouncer and connecting to a
different instance than the original.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>