### PR TITLE
Flesh out more models

### DIFF
--- a/internal/datasource/cardano_db_sync/models/block.go
+++ b/internal/datasource/cardano_db_sync/models/block.go
@@ -12,7 +12,7 @@ type Block struct {
 	EpochSlotNumber uint32     `gorm:"column:epoch_slot_no"`
 	BlockNumber     uint32     `gorm:"column:block_no"`
 	PreviousID      int64      `gorm:"column:previous_id"`
-	SlotLeaderID    int64      `gorm:"column:slot_leader_id"`
+	SlotLeaderID    int64      `gorm:"column:slot_leader_id"` // slot_leader(id)
 	Size            uint32     `gorm:"column:size"`
 	Time            *time.Time `gorm:"column:time"`
 	TxCount         int64      `gorm:"column:tx_count"`

--- a/internal/datasource/cardano_db_sync/models/block.go
+++ b/internal/datasource/cardano_db_sync/models/block.go
@@ -6,12 +6,12 @@ import (
 
 type Block struct {
 	Id              int64      `gorm:"column:id"`
-	Hash            []byte     `gorm:"column:hash"`
+	Hash            []byte     `gorm:"column:hash"` // This is a "hash32type" column
 	EpochNumber     uint16     `gorm:"column:epoch_no"`
 	SlotNumber      uint32     `gorm:"column:slot_no"`
 	EpochSlotNumber uint32     `gorm:"column:epoch_slot_no"`
 	BlockNumber     uint32     `gorm:"column:block_no"`
-	PreviousID      int64      `gorm:"column:previous_id"`
+	PreviousID      int64      `gorm:"column:previous_id"`    // block(id)
 	SlotLeaderID    int64      `gorm:"column:slot_leader_id"` // slot_leader(id)
 	Size            uint32     `gorm:"column:size"`
 	Time            *time.Time `gorm:"column:time"`
@@ -19,8 +19,8 @@ type Block struct {
 	ProtoMajor      uint16     `gorm:"column:proto_major"`
 	ProtoMinor      uint16     `gorm:"column:proto_minor"`
 	VrfKey          string     `gorm:"column:vrf_key"`
-	OpCert          []byte     `gorm:"column:op_cert"`
-	OpCertCounter   uint32     `gorm:"column:op_cert_counter"`
+	OpCert          []byte     `gorm:"column:op_cert"`         // This is a "hash32type" column
+	OpCertCounter   uint32     `gorm:"column:op_cert_counter"` // This is a "word63type" column
 }
 
 // Override default pluralized table name

--- a/internal/datasource/cardano_db_sync/models/cost_model.go
+++ b/internal/datasource/cardano_db_sync/models/cost_model.go
@@ -1,0 +1,33 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+)
+
+type CostModel struct {
+	Id      int64 `gorm:"column:id"`
+	Costs   jsonb `gorm:"column:costs"`    // This is a "jsonb" column
+	BlockId int64 `gorm:"column:block_id"` // block(id)
+}
+
+// Override default pluralized table name
+func (CostModel) TableName() string {
+	return "cost_model"
+}
+
+// TODO: this goes elsewhere
+// support jsonb column type
+type jsonb map[string]interface{}
+
+func (j jsonb) Value() (driver.Value, error) {
+	retVal, err := json.Marshal(j)
+	return string(retVal), err
+}
+
+func (j *jsonb) Scan(value interface{}) error {
+	if err := json.Unmarshal(value.([]byte), &j); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/datasource/cardano_db_sync/models/epoch.go
+++ b/internal/datasource/cardano_db_sync/models/epoch.go
@@ -5,9 +5,8 @@ import (
 )
 
 type Epoch struct {
-	Id int64 `gorm:"column:id"`
-	// This data type may not be large enough. The DB column uses NUMERIC(38, 0)
-	OutSum      uint64     `gorm:"column:out_sum"`
+	Id          int64      `gorm:"column:id"`
+	OutSum      uint64     `gorm:"column:out_sum"` // This data type may not be large enough. The DB column uses NUMERIC(38, 0)
 	Fees        uint64     `gorm:"column:fees"`
 	TxCount     uint32     `gorm:"column:tx_count"`
 	BlockCount  uint32     `gorm:"column:blk_count"`

--- a/internal/datasource/cardano_db_sync/models/epoch.go
+++ b/internal/datasource/cardano_db_sync/models/epoch.go
@@ -6,8 +6,8 @@ import (
 
 type Epoch struct {
 	Id          int64      `gorm:"column:id"`
-	OutSum      uint64     `gorm:"column:out_sum"` // This data type may not be large enough. The DB column uses NUMERIC(38, 0)
-	Fees        uint64     `gorm:"column:fees"`
+	OutSum      uint64     `gorm:"column:out_sum"` // This type may not be large enough. The DB column uses NUMERIC(38, 0)
+	Fees        uint64     `gorm:"column:fees"`    // This is a "lovelace" column
 	TxCount     uint32     `gorm:"column:tx_count"`
 	BlockCount  uint32     `gorm:"column:blk_count"`
 	EpochNumber uint32     `gorm:"column:no"`

--- a/internal/datasource/cardano_db_sync/models/epoch_param.go
+++ b/internal/datasource/cardano_db_sync/models/epoch_param.go
@@ -19,18 +19,18 @@ type EpochParam struct {
 	Entropy             []byte  `gorm:"column:entropy"` // This is a "hash32type" column
 	ProtocolMajor       uint32  `gorm:"column:protocol_major"`
 	ProtocolMinor       uint32  `gorm:"column:protocol_minor"`
-	MinUtxoValue        uint32  `gorm:"column:min_utxo_value"`      // This is a "lovelace" column
-	MinPoolCost         uint32  `gorm:"column:min_pool_cost"`       // This is a "lovelace" column
+	MinUtxoValue        uint64  `gorm:"column:min_utxo_value"`      // This is a "lovelace" column
+	MinPoolCost         uint64  `gorm:"column:min_pool_cost"`       // This is a "lovelace" column
 	Nonce               []byte  `gorm:"column:nonce"`               // This is a "hash32type" column
-	CoinsPerUtxoWord    uint32  `gorm:"column:coins_per_utxo_word"` // This is a "lovelace" column
+	CoinsPerUtxoWord    uint64  `gorm:"column:coins_per_utxo_word"` // This is a "lovelace" column
 	CostModelId         int64   `gorm:"column:cost_model_id"`       // cost_model(id)
 	PriceMem            float32 `gorm:"column:price_mem"`
 	PriceStep           float32 `gorm:"column:price_step"`
-	MaxTxExMem          string  `gorm:"column:max_tx_ex_mem"`      // This is a "word64type" column
-	MaxTxExSteps        string  `gorm:"column:max_tx_ex_steps"`    // This is a "word64type" column
-	MaxBlockExMem       string  `gorm:"column:max_block_ex_mem"`   // This is a "word64type" column
-	MaxBlockExSteps     string  `gorm:"column:max_block_ex_steps"` // This is a "word64type" column
-	MaxValSize          string  `gorm:"column:max_val_size"`       // This is a "word64type" column
+	MaxTxExMem          string  `gorm:"column:max_tx_ex_mem"`      // This is a "word63type" column
+	MaxTxExSteps        string  `gorm:"column:max_tx_ex_steps"`    // This is a "word63type" column
+	MaxBlockExMem       string  `gorm:"column:max_block_ex_mem"`   // This is a "word63type" column
+	MaxBlockExSteps     string  `gorm:"column:max_block_ex_steps"` // This is a "word63type" column
+	MaxValSize          string  `gorm:"column:max_val_size"`       // This is a "word63type" column
 	CollateralPercent   uint32  `gorm:"column:collateral_percent"`
 	MaxCollateralInputs uint32  `gorm:"column:max_collateral_inputs"`
 	BlockId             int64   `gorm:column:block_id"` // block(id)

--- a/internal/datasource/cardano_db_sync/models/epoch_param.go
+++ b/internal/datasource/cardano_db_sync/models/epoch_param.go
@@ -8,29 +8,29 @@ type EpochParam struct {
 	MaxBlockSize        uint32  `gorm:"column:max_block_size"`
 	MaxTxSize           uint32  `gorm:"column:max_tx_size"`
 	MaxBhSize           uint32  `gorm:"column:max_bh_size"`
-	KeyDeposit          uint64  `gorm:"column:key_deposit"`
-	PoolDeposit         uint64  `gorm:"column:pool_deposit"`
+	KeyDeposit          uint64  `gorm:"column:key_deposit"`  // This is a "lovelace" column
+	PoolDeposit         uint64  `gorm:"column:pool_deposit"` // This is a "lovelace" column
 	MaxEpoch            uint32  `gorm:"column:max_epoch"`
 	OptimalPoolCount    uint32  `gorm:"column:optimal_pool_count"`
 	Influence           float32 `gorm:"column:influence"`
 	MonetaryExpandRate  float32 `gorm:"column:monetary_expand_rate"`
 	TreasuryGrowthRate  float32 `gorm:"column:treasury_growth_rate"`
 	Decentralisation    float32 `gorm:"column:decentralisation"`
-	Entropy             string  `gorm:"column:entropy"`
+	Entropy             []byte  `gorm:"column:entropy"` // This is a "hash32type" column
 	ProtocolMajor       uint32  `gorm:"column:protocol_major"`
 	ProtocolMinor       uint32  `gorm:"column:protocol_minor"`
-	MinUtxoValue        uint32  `gorm:"column:min_utxo_value"`
-	MinPoolCost         uint32  `gorm:"column:min_pool_cost"`
-	Nonce               string  `gorm:"column:nonce"`
-	CoinsPerUtxoWord    uint32  `gorm:"column:coins_per_utxo_word"`
-	CostModelId         int64   `gorm:"column:cost_model_id"` // cost_model(id)
+	MinUtxoValue        uint32  `gorm:"column:min_utxo_value"`      // This is a "lovelace" column
+	MinPoolCost         uint32  `gorm:"column:min_pool_cost"`       // This is a "lovelace" column
+	Nonce               []byte  `gorm:"column:nonce"`               // This is a "hash32type" column
+	CoinsPerUtxoWord    uint32  `gorm:"column:coins_per_utxo_word"` // This is a "lovelace" column
+	CostModelId         int64   `gorm:"column:cost_model_id"`       // cost_model(id)
 	PriceMem            float32 `gorm:"column:price_mem"`
 	PriceStep           float32 `gorm:"column:price_step"`
-	MaxTxExMem          string  `gorm:"column:max_tx_ex_mem"`
-	MaxTxExSteps        string  `gorm:"column:max_tx_ex_steps"`
-	MaxBlockExMem       string  `gorm:"column:max_block_ex_mem"`
-	MaxBlockExSteps     string  `gorm:"column:max_block_ex_steps"`
-	MaxValSize          string  `gorm:"column:max_val_size"`
+	MaxTxExMem          string  `gorm:"column:max_tx_ex_mem"`      // This is a "word64type" column
+	MaxTxExSteps        string  `gorm:"column:max_tx_ex_steps"`    // This is a "word64type" column
+	MaxBlockExMem       string  `gorm:"column:max_block_ex_mem"`   // This is a "word64type" column
+	MaxBlockExSteps     string  `gorm:"column:max_block_ex_steps"` // This is a "word64type" column
+	MaxValSize          string  `gorm:"column:max_val_size"`       // This is a "word64type" column
 	CollateralPercent   uint32  `gorm:"column:collateral_percent"`
 	MaxCollateralInputs uint32  `gorm:"column:max_collateral_inputs"`
 	BlockId             int64   `gorm:column:block_id"` // block(id)

--- a/internal/datasource/cardano_db_sync/models/epoch_param.go
+++ b/internal/datasource/cardano_db_sync/models/epoch_param.go
@@ -1,0 +1,42 @@
+package models
+
+type EpochParam struct {
+	Id                  int64   `gorm:"column:id"`
+	EpochNumber         uint32  `gorm:"column:epoch_num"`
+	MinFeeA             uint32  `gorm:"column:min_fee_a"`
+	MinFeeB             uint32  `gorm:"column:min_fee_b"`
+	MaxBlockSize        uint32  `gorm:"column:max_block_size"`
+	MaxTxSize           uint32  `gorm:"column:max_tx_size"`
+	MaxBhSize           uint32  `gorm:"column:max_bh_size"`
+	KeyDeposit          uint64  `gorm:"column:key_deposit"`
+	PoolDeposit         uint64  `gorm:"column:pool_deposit"`
+	MaxEpoch            uint32  `gorm:"column:max_epoch"`
+	OptimalPoolCount    uint32  `gorm:"column:optimal_pool_count"`
+	Influence           float32 `gorm:"column:influence"`
+	MonetaryExpandRate  float32 `gorm:"column:monetary_expand_rate"`
+	TreasuryGrowthRate  float32 `gorm:"column:treasury_growth_rate"`
+	Decentralisation    float32 `gorm:"column:decentralisation"`
+	Entropy             string  `gorm:"column:entropy"`
+	ProtocolMajor       uint32  `gorm:"column:protocol_major"`
+	ProtocolMinor       uint32  `gorm:"column:protocol_minor"`
+	MinUtxoValue        uint32  `gorm:"column:min_utxo_value"`
+	MinPoolCost         uint32  `gorm:"column:min_pool_cost"`
+	Nonce               string  `gorm:"column:nonce"`
+	CoinsPerUtxoWord    uint32  `gorm:"column:coins_per_utxo_word"`
+	CostModelId         int64   `gorm:"column:cost_model_id"` // cost_model(id)
+	PriceMem            float32 `gorm:"column:price_mem"`
+	PriceStep           float32 `gorm:"column:price_step"`
+	MaxTxExMem          string  `gorm:"column:max_tx_ex_mem"`
+	MaxTxExSteps        string  `gorm:"column:max_tx_ex_steps"`
+	MaxBlockExMem       string  `gorm:"column:max_block_ex_mem"`
+	MaxBlockExSteps     string  `gorm:"column:max_block_ex_steps"`
+	MaxValSize          string  `gorm:"column:max_val_size"`
+	CollateralPercent   uint32  `gorm:"column:collateral_percent"`
+	MaxCollateralInputs uint32  `gorm:"column:max_collateral_inputs"`
+	BlockId             int64   `gorm:column:block_id"` // block(id)
+}
+
+// Override default pluralized table name
+func (EpochParam) TableName() string {
+	return "epoch_param"
+}

--- a/internal/datasource/cardano_db_sync/models/epoch_stake.go
+++ b/internal/datasource/cardano_db_sync/models/epoch_stake.go
@@ -1,0 +1,14 @@
+package models
+
+type EpochStake struct {
+	Id          int64  `gorm:"column:id"`
+	AddrId      int64  `gorm:"column:addr_id"` // stake_address(id)
+	PoolId      int64  `gorm:"column:pool_id"` // pool_hash(id)
+	Amount      uint32 `gorm:"column:amount"`
+	EpochNumber uint32 `gorm:"column:epoch_no"`
+}
+
+// Override default table name
+func (EpochStake) TableName() string {
+	return "epoch_stake"
+}

--- a/internal/datasource/cardano_db_sync/models/pool_hash.go
+++ b/internal/datasource/cardano_db_sync/models/pool_hash.go
@@ -1,0 +1,12 @@
+package models
+
+type PoolHash struct {
+	Id      int64  `gorm:"column:id"`
+	HashRaw string `gorm:"column:hash_raw"` // This is a "hash28type"
+	View    string `gorm:"column:view"`
+}
+
+// Override default pluralized table name
+func (PoolHash) TableName() string {
+	return "pool_hash"
+}

--- a/internal/datasource/cardano_db_sync/models/pool_hash.go
+++ b/internal/datasource/cardano_db_sync/models/pool_hash.go
@@ -2,7 +2,7 @@ package models
 
 type PoolHash struct {
 	Id      int64  `gorm:"column:id"`
-	HashRaw string `gorm:"column:hash_raw"` // This is a "hash28type"
+	HashRaw []byte `gorm:"column:hash_raw"` // This is a "hash28type" column
 	View    string `gorm:"column:view"`
 }
 

--- a/internal/datasource/cardano_db_sync/models/pool_metadata_ref.go
+++ b/internal/datasource/cardano_db_sync/models/pool_metadata_ref.go
@@ -1,0 +1,14 @@
+package models
+
+type PoolMetadataRef struct {
+	Id            int64  `gorm:"column:id"`
+	HashId        int64  `gorm:"column:hash_id"` // pool_hash(id)
+	Url           string `gorm:"column:url"`
+	Hash          []byte `gorm:"column:hash"`             // This is a "hash32type" column
+	RegisterdTxId int64  `gorm:"column:registered_tx_id"` // tx(id)
+}
+
+// Override default pluralized table name
+func (PoolMetadataRef) TableName() string {
+	return "pool_metadata_ref"
+}

--- a/internal/datasource/cardano_db_sync/models/pool_retire.go
+++ b/internal/datasource/cardano_db_sync/models/pool_retire.go
@@ -3,7 +3,7 @@ package models
 type PoolRetire struct {
 	Id            int64  `gorm:"column:id"`
 	HashId        int64  `gorm:"column:hash_id"` // pool_hash(id)
-	CertIndex     int64  `gorm:"column:cert_index"`
+	CertIndex     int32  `gorm:"column:cert_index"`
 	AnnounceTxnId int64  `gorm:"column:announced_tx_id"` // tx(id)
 	RetiringEpoch uint64 `gorm:"column:retiring_epoch"`
 }

--- a/internal/datasource/cardano_db_sync/models/pool_retire.go
+++ b/internal/datasource/cardano_db_sync/models/pool_retire.go
@@ -1,0 +1,14 @@
+package models
+
+type PoolRetire struct {
+	Id            int64  `gorm:"column:id"`
+	HashId        int64  `gorm:"column:hash_id"` // pool_hash(id)
+	CertIndex     int64  `gorm:"column:cert_index"`
+	AnnounceTxnId int64  `gorm:"column:announced_tx_id"` // tx(id)
+	RetiringEpoch uint64 `gorm:"column:retiring_epoch"`
+}
+
+// Override default pluralized table name
+func (PoolRetire) TableName() string {
+	return "pool_retire"
+}

--- a/internal/datasource/cardano_db_sync/models/pool_update.go
+++ b/internal/datasource/cardano_db_sync/models/pool_update.go
@@ -1,17 +1,17 @@
 package models
 
 type PoolUpdate struct {
-	Id            int64  `gorm:"column:id"`
-	HashId        int64  `gorm:"column:hash_id"` // pool_hash(id)
-	CertIndex     int64  `gorm:"column:cert_index"`
-	VrfKeyHash    []byte `gorm:"column:vrf_key_hash"` // This is a "hash32type" column
-	Pledge        uint64 `gorm:"column:pledge"`       // This is a "lovelace" column
-	RewardAddr    string `gorm:"column:reward_addr"`  // This is a "addr29type" column
-	ActiveEpochNo int64  `gorm:"column:active_epoch_no"`
-	MetaId        int64  `gorm:"column:meta_id"` // pool_metadata_ref(id)
-	Margin        float  `gorm:"column:margin"`
-	FixedCost     uint64 `gorm:"column:fixed_cost"`       // This is a "lovelace" column
-	RegisterdTxId int64  `gorm:"column:registered_tx_id"` // tx(id)
+	Id            int64   `gorm:"column:id"`
+	HashId        int64   `gorm:"column:hash_id"` // pool_hash(id)
+	CertIndex     int64   `gorm:"column:cert_index"`
+	VrfKeyHash    []byte  `gorm:"column:vrf_key_hash"` // This is a "hash32type" column
+	Pledge        uint64  `gorm:"column:pledge"`       // This is a "lovelace" column
+	RewardAddr    string  `gorm:"column:reward_addr"`  // This is a "addr29type" column
+	ActiveEpochNo int64   `gorm:"column:active_epoch_no"`
+	MetaId        int64   `gorm:"column:meta_id"` // pool_metadata_ref(id)
+	Margin        float32 `gorm:"column:margin"`
+	FixedCost     uint64  `gorm:"column:fixed_cost"`       // This is a "lovelace" column
+	RegisterdTxId int64   `gorm:"column:registered_tx_id"` // tx(id)
 }
 
 // Override default pluralized table name

--- a/internal/datasource/cardano_db_sync/models/pool_update.go
+++ b/internal/datasource/cardano_db_sync/models/pool_update.go
@@ -1,0 +1,20 @@
+package models
+
+type PoolUpdate struct {
+	Id            int64  `gorm:"column:id"`
+	HashId        int64  `gorm:"column:hash_id"` // pool_hash(id)
+	CertIndex     int64  `gorm:"column:cert_index"`
+	VrfKeyHash    []byte `gorm:"column:vrf_key_hash"` // This is a "hash32type" column
+	Pledge        uint64 `gorm:"column:pledge"`       // This is a "lovelace" column
+	RewardAddr    string `gorm:"column:reward_addr"`  // This is a "addr29type" column
+	ActiveEpochNo int64  `gorm:"column:active_epoch_no"`
+	MetaId        int64  `gorm:"column:meta_id"` // pool_metadata_ref(id)
+	Margin        float  `gorm:"column:margin"`
+	FixedCost     uint64 `gorm:"column:fixed_cost"`       // This is a "lovelace" column
+	RegisterdTxId int64  `gorm:"column:registered_tx_id"` // tx(id)
+}
+
+// Override default pluralized table name
+func (PoolUpdate) TableName() string {
+	return "pool_update"
+}

--- a/internal/datasource/cardano_db_sync/models/pool_update.go
+++ b/internal/datasource/cardano_db_sync/models/pool_update.go
@@ -3,7 +3,7 @@ package models
 type PoolUpdate struct {
 	Id            int64   `gorm:"column:id"`
 	HashId        int64   `gorm:"column:hash_id"` // pool_hash(id)
-	CertIndex     int64   `gorm:"column:cert_index"`
+	CertIndex     int32   `gorm:"column:cert_index"`
 	VrfKeyHash    []byte  `gorm:"column:vrf_key_hash"` // This is a "hash32type" column
 	Pledge        uint64  `gorm:"column:pledge"`       // This is a "lovelace" column
 	RewardAddr    string  `gorm:"column:reward_addr"`  // This is a "addr29type" column

--- a/internal/datasource/cardano_db_sync/models/slot_leader.go
+++ b/internal/datasource/cardano_db_sync/models/slot_leader.go
@@ -2,7 +2,7 @@ package models
 
 type SlotLeader struct {
 	Id          int64  `gorm:"column:id"`
-	Hash        string `gorm:"column:hash"`
+	Hash        []byte `gorm:"column:hash"`    // This is a "hash28type" column
 	PoolId      int64  `gorm:"column:pool_id"` // pool_hash(id)
 	Description string `gorm:"column:description"`
 }

--- a/internal/datasource/cardano_db_sync/models/slot_leader.go
+++ b/internal/datasource/cardano_db_sync/models/slot_leader.go
@@ -1,0 +1,13 @@
+package models
+
+type SlotLeader struct {
+	Id          int64  `gorm:"column:id"`
+	Hash        string `gorm:"column:hash"`
+	PoolId      int64  `gorm:"column:pool_id"` // pool_hash(id)
+	Description string `gorm:"column:description"`
+}
+
+// Override default table name
+func (SlotLeader) TableName() string {
+	return "slot_leader"
+}

--- a/internal/datasource/cardano_db_sync/models/stake_address.go
+++ b/internal/datasource/cardano_db_sync/models/stake_address.go
@@ -1,0 +1,14 @@
+package models
+
+type StakeAddress struct {
+	Id            int64  `gorm:"column:id"`
+	HashRaw       []byte `gorm:"column:hash_raw"` // This is a "addr29type" column
+	View          string `gorm:"column:view"`
+	ScriptHash    []byte `gorm:"column:script_hash"`
+	RegisterdTxId int64  `gorm:"column:registered_tx_id"` // tx(id)
+}
+
+// Override default pluralized table name
+func (StakeAddress) TableName() string {
+	return "stake_address"
+}

--- a/internal/datasource/cardano_db_sync/models/stake_address.go
+++ b/internal/datasource/cardano_db_sync/models/stake_address.go
@@ -4,7 +4,7 @@ type StakeAddress struct {
 	Id            int64  `gorm:"column:id"`
 	HashRaw       []byte `gorm:"column:hash_raw"` // This is a "addr29type" column
 	View          string `gorm:"column:view"`
-	ScriptHash    []byte `gorm:"column:script_hash"`
+	ScriptHash    []byte `gorm:"column:script_hash"`      // This is a "hash28type" column
 	RegisterdTxId int64  `gorm:"column:registered_tx_id"` // tx(id)
 }
 

--- a/internal/datasource/cardano_db_sync/models/tx.go
+++ b/internal/datasource/cardano_db_sync/models/tx.go
@@ -1,0 +1,21 @@
+package models
+
+type Tx struct {
+	Id             int64  `gorm:"column:id"`
+	Hash           string `gorm:"column:hash"`           // This is a "hash32type" column
+	BlockId        int64  `gorm:"column:block_id"`       // block(id)
+	BlockIndex     uint32 `gorm:"column:block_index"`
+	OutSum         uint64 `gorm:"column:out_sum"`        // This is a "lovelace" column
+	Fee            uint64 `gorm:"column:fee"`            // This is a "lovelace" column
+	Deposit        int64  `gorm:"column:deposit"`
+	Size           uint32 `gorm:"column:size"`
+	InvalidBefore  string `gorm:"column:invalid_before"` // This is a "word64type" column
+	InvalidAfter   string `gorm:"column:invalid_after"`  // This is a "word64type" column
+	ValidContract  bool   `gorm:"column:valid_contract"`
+	ScriptSize     uint32 `gorm:"column:script_size"`
+}
+
+// Override default pluralized table name
+func (Tx) TableName() string {
+	return "tx"
+}

--- a/internal/datasource/cardano_db_sync/models/tx.go
+++ b/internal/datasource/cardano_db_sync/models/tx.go
@@ -1,18 +1,18 @@
 package models
 
 type Tx struct {
-	Id             int64  `gorm:"column:id"`
-	Hash           string `gorm:"column:hash"`           // This is a "hash32type" column
-	BlockId        int64  `gorm:"column:block_id"`       // block(id)
-	BlockIndex     uint32 `gorm:"column:block_index"`
-	OutSum         uint64 `gorm:"column:out_sum"`        // This is a "lovelace" column
-	Fee            uint64 `gorm:"column:fee"`            // This is a "lovelace" column
-	Deposit        int64  `gorm:"column:deposit"`
-	Size           uint32 `gorm:"column:size"`
-	InvalidBefore  string `gorm:"column:invalid_before"` // This is a "word64type" column
-	InvalidAfter   string `gorm:"column:invalid_after"`  // This is a "word64type" column
-	ValidContract  bool   `gorm:"column:valid_contract"`
-	ScriptSize     uint32 `gorm:"column:script_size"`
+	Id            int64  `gorm:"column:id"`
+	Hash          []byte `gorm:"column:hash"`     // This is a "hash32type" column
+	BlockId       int64  `gorm:"column:block_id"` // block(id)
+	BlockIndex    uint32 `gorm:"column:block_index"`
+	OutSum        uint64 `gorm:"column:out_sum"` // This is a "lovelace" column
+	Fee           uint64 `gorm:"column:fee"`     // This is a "lovelace" column
+	Deposit       int64  `gorm:"column:deposit"`
+	Size          uint32 `gorm:"column:size"`
+	InvalidBefore string `gorm:"column:invalid_before"` // This is a "word64type" column
+	InvalidAfter  string `gorm:"column:invalid_after"`  // This is a "word64type" column
+	ValidContract bool   `gorm:"column:valid_contract"`
+	ScriptSize    uint32 `gorm:"column:script_size"`
 }
 
 // Override default pluralized table name


### PR DESCRIPTION
Include some additional models which are needed to fully flesh out the available data in the Block and Epoch models.

- Document columns which reference other columns
- Block references SlotLeader
- EpochParam is created which references CostModel
- CostModel requires creating `jsonb` data type
- EpochStake is created which references StakeAddress
- PoolRetire and PoolUpdate for tracking stake pool changes
- Tx is created as it is referenced by several other models