### PR TITLE
Support per-epoch staking amounts

### DIFF
--- a/internal/api/v1/epoch/endpoints.go
+++ b/internal/api/v1/epoch/endpoints.go
@@ -7,10 +7,19 @@ import (
 )
 
 func ConfigureRoutes(g *gin.RouterGroup) {
+	g.GET("/epoch", HandleGetEpochList)
 	groupEpoch := g.Group("/epoch")
-	groupEpoch.GET("/:number", HandleGetEpoch)
+	// Operates on epoch
 	groupEpoch.GET("/current", HandleGetEpochLatest)
 	groupEpoch.GET("/latest", HandleGetEpochLatest)
+	// Specific epoch
+	groupEpoch.GET("/:number", HandleGetEpoch)
+	groupEpochNum := groupEpoch.Group("/:number")
+	// Stake
+	groupEpochNum.GET("/stake", HandleGetEpochStake)
+	groupEpochStake := groupEpochNum.Group("/stake")
+	groupEpochStake.GET("/account/:account", HandleGetEpochStakeByAccount)
+	groupEpochStake.GET("/pool/:pool", HandleGetEpochStakeByPool)
 }
 
 func HandleGetEpoch(c *gin.Context) {
@@ -59,5 +68,121 @@ func HandleGetEpochLatest(c *gin.Context) {
 	}
 	// Create response from returned item
 	r := NewEpochResponse(&epoch)
+	c.JSON(200, r)
+}
+
+type StakeAmount struct {
+	Amount uint64
+}
+
+func HandleGetEpochStake(c *gin.Context) {
+	var uriParams GetEpochUriParams
+	if err := c.ShouldBindUri(&uriParams); err != nil {
+		// TODO: provide a more useful error message
+		c.JSON(400, gin.H{"msg": err.Error()})
+		return
+	}
+	// Retrieve epoch from DB
+	var epochStake models.EpochStake
+	var amount StakeAmount
+	db := cardano_db_sync.GetHandle()
+	result := db.Model(&epochStake).Where(&models.EpochStake{
+		EpochNumber: uriParams.Number}).Select("SUM(amount) AS amount").Find(&amount)
+	if result.Error != nil {
+		// Not found
+		if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+			c.JSON(404, gin.H{"msg": "epoch not found"})
+			return
+		}
+		// Some other database error
+		// TODO: log this failure
+		c.JSON(500, gin.H{"msg": "unexpected error"})
+		return
+	}
+	// Create response from returned item
+	r := NewEpochStakeResponse(&amount)
+	c.JSON(200, r)
+}
+
+func HandleGetEpochStakeByAccount(c *gin.Context) {
+	var uriParams GetEpochStakeUriParams
+	if err := c.ShouldBindUri(&uriParams); err != nil {
+		// TODO: provide a more useful error message
+		c.JSON(400, gin.H{"msg": err.Error()})
+		return
+	}
+	// Retrieve epoch from DB
+	var epochStake models.EpochStake
+	var amount StakeAmount
+	db := cardano_db_sync.GetHandle()
+	addrIdQuery := db.Select("id").Where("view = ?", uriParams.Account).Table("stake_address")
+	result := db.Model(&epochStake).Where("epoch_no = ? AND addr_id = (?)", uriParams.Number, addrIdQuery).Select("SUM(amount) AS amount").Find(&amount)
+	if result.Error != nil {
+		// Not found
+		if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+			c.JSON(404, gin.H{"msg": "epoch not found"})
+			return
+		}
+		// Some other database error
+		// TODO: log this failure
+		c.JSON(500, gin.H{"msg": "unexpected error"})
+		return
+	}
+	// Create response from returned item
+	r := NewEpochStakeResponse(&amount)
+	c.JSON(200, r)
+}
+
+func HandleGetEpochStakeByPool(c *gin.Context) {
+	var uriParams GetEpochStakeUriParams
+	if err := c.ShouldBindUri(&uriParams); err != nil {
+		// TODO: provide a more useful error message
+		c.JSON(400, gin.H{"msg": err.Error()})
+		return
+	}
+	// Retrieve epoch from DB
+	var epochStake models.EpochStake
+	var amount StakeAmount
+	db := cardano_db_sync.GetHandle()
+	poolIdQuery := db.Select("id").Where("view = ?", uriParams.Pool).Table("pool_hash")
+	result := db.Model(&epochStake).Where("epoch_no = ? AND pool_id = (?)", uriParams.Number, poolIdQuery).Select("SUM(amount) AS amount").Find(&amount)
+	if result.Error != nil {
+		// Not found
+		if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+			c.JSON(404, gin.H{"msg": "epoch not found"})
+			return
+		}
+		// Some other database error
+		// TODO: log this failure
+		c.JSON(500, gin.H{"msg": "unexpected error"})
+		return
+	}
+	// Create response from returned item
+	r := NewEpochStakeResponse(&amount)
+	c.JSON(200, r)
+}
+
+func HandleGetEpochList(c *gin.Context) {
+	// Retrieve epochs from DB
+	db := cardano_db_sync.GetHandle()
+	var epochs []*models.Epoch
+	// TODO: make this paginate, don't limit specifically
+	result := db.Model(&models.Epoch{}).Limit(100).Find(&epochs)
+	if result.Error != nil {
+		// Not found
+		if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+			c.JSON(404, gin.H{"msg": "block not found"})
+			return
+		}
+		// Some other database error
+		// TODO: log this failure
+		c.JSON(500, gin.H{"msg": "unexpected error"})
+		return
+	}
+	// Create response from returned item
+	var r []*EpochResponse
+        for _, v := range epochs {
+		r = append(r, NewEpochResponse(v))
+	}
 	c.JSON(200, r)
 }

--- a/internal/api/v1/epoch/requests.go
+++ b/internal/api/v1/epoch/requests.go
@@ -4,3 +4,10 @@ package epoch
 type GetEpochUriParams struct {
 	Number uint32 `uri:"number" binding:"required"`
 }
+
+// URI params for GetEpochStake
+type GetEpochStakeUriParams struct {
+	Number  uint32 `uri:"number" binding:"required"`
+	Account string `uri:"account"`
+	Pool    string `uri:"pool"`
+}

--- a/internal/api/v1/epoch/responses.go
+++ b/internal/api/v1/epoch/responses.go
@@ -15,6 +15,10 @@ type EpochResponse struct {
 	EndTime     *time.Time `json:"end_time"`
 }
 
+type EpochStakeResponse struct {
+	Amount uint64 `json:"amount"`
+}
+
 func NewEpochResponse(e *models.Epoch) *EpochResponse {
 	r := &EpochResponse{
 		OutSum:      e.OutSum,
@@ -24,6 +28,13 @@ func NewEpochResponse(e *models.Epoch) *EpochResponse {
 		EpochNumber: e.EpochNumber,
 		StartTime:   e.StartTime,
 		EndTime:     e.EndTime,
+	}
+	return r
+}
+
+func NewEpochStakeResponse(e *StakeAmount) *EpochStakeResponse {
+	r := &EpochStakeResponse{
+		Amount: e.Amount,
 	}
 	return r
 }


### PR DESCRIPTION
Add rudimentary support for `/block` and `/epoch` lists. These are
currently hard-coded to a max limit of 100 items. Pagination will come
later.

* /block - list of block objects
* /epoch - list of epoch objects
* /epoch/:number/stake - active stake per epoch
* .../stake/account/:account - active stake by account
* .../stake/pool/:pool - active stake by pool

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>