### PR TITLE
Implement totals endpoint

### DIFF
--- a/internal/api/v0/totals/endpoints.go
+++ b/internal/api/v0/totals/endpoints.go
@@ -1,0 +1,60 @@
+package totals
+
+import (
+	"github.com/cloudstruct/blockchain-query-api/internal/datasource/cardano_db_sync"
+	"github.com/cloudstruct/blockchain-query-api/internal/datasource/cardano_db_sync/models"
+	"github.com/gin-gonic/gin"
+	"strconv"
+)
+
+func ConfigureRoutes(g *gin.RouterGroup) {
+	g.GET("/totals", HandleGetTotals)
+	g.POST("/totals", HandleGetTotals)
+}
+
+func HandleGetTotals(c *gin.Context) {
+	epochNumber := c.DefaultPostForm("_epoch_no", "")
+
+	var adaPots []*models.AdaPots
+	db := cardano_db_sync.GetHandle()
+	if epochNumber != "" {
+		epoch, err := strconv.ParseUint(epochNumber, 10, 32)
+		if err != nil {
+			c.JSON(400, gin.H{"msg": "could not parse _epoch_no"})
+			return
+		}
+		result := db.Model(&adaPots).Where(&models.AdaPots{
+			EpochNumber: uint32(epoch)}).Order("epoch_no desc").Find(&adaPots)
+		if result.Error != nil {
+			// Not found
+			if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+				c.JSON(404, gin.H{"msg": "epoch not found"})
+				return
+			}
+			// Some other database error
+			// TODO: log this failure
+			c.JSON(500, gin.H{"msg": "unexpected error"})
+			return
+		}
+	} else {
+		// TODO: make this paginate, don't limit specifically
+		result := db.Order("epoch_no desc").Limit(100).Find(&adaPots)
+		if result.Error != nil {
+			// Not found
+			if cardano_db_sync.IsRecordNotFoundError(result.Error) {
+				c.JSON(404, gin.H{"msg": "records not found"})
+				return
+			}
+			// Some other database error
+			// TODO: log this failure
+			c.JSON(500, gin.H{"msg": "unexpected error"})
+			return
+		}
+	}
+	// Create response from returned item
+	var r []*TotalsResponse
+	for _, v := range adaPots {
+		r = append(r, NewTotalsResponse(v))
+	}
+	c.JSON(200, r)
+}

--- a/internal/api/v0/totals/responses.go
+++ b/internal/api/v0/totals/responses.go
@@ -1,0 +1,27 @@
+package totals
+
+import (
+	"github.com/cloudstruct/blockchain-query-api/internal/datasource/cardano_db_sync/models"
+	"strconv"
+)
+
+type TotalsResponse struct {
+	EpochNumber uint32 `json:"epoch_no"`
+	Circulation string `json:"circulation"`
+	Treasury    string `json:"treasury"`
+	Rewards     string `json:"reward"`
+	Supply      string `json:"supply"`
+	Reserves    string `json:"reserves"`
+}
+
+func NewTotalsResponse(t *models.AdaPots) *TotalsResponse {
+	r := &TotalsResponse{
+		EpochNumber: t.EpochNumber,
+		Circulation: strconv.FormatUint(t.Utxo, 10),
+		Treasury:    strconv.FormatUint(t.Treasury, 10),
+		Rewards:     strconv.FormatUint(t.Rewards, 10),
+		Supply:      strconv.FormatUint((t.Treasury + t.Rewards + t.Utxo + t.Deposits + t.Fees), 10),
+		Reserves:    strconv.FormatUint(t.Reserves, 10),
+	}
+	return r
+}

--- a/internal/api/v0/v0.go
+++ b/internal/api/v0/v0.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cloudstruct/blockchain-query-api/internal/api/v0/epoch"
 	"github.com/cloudstruct/blockchain-query-api/internal/api/v0/meta"
 	"github.com/cloudstruct/blockchain-query-api/internal/api/v0/tip"
+	"github.com/cloudstruct/blockchain-query-api/internal/api/v0/totals"
 	"github.com/gin-gonic/gin"
 )
 
@@ -13,4 +14,5 @@ func ConfigureRoutes(g *gin.RouterGroup) {
 	epoch.ConfigureRoutes(g)
 	meta.ConfigureRoutes(g)
 	tip.ConfigureRoutes(g)
+	totals.ConfigureRoutes(g)
 }


### PR DESCRIPTION
The totals endpoint is a representation of the adapots table in
`cardano-db-sync` and supports sending `_epoch_no` as a form argument. This
functions the same as Koios `/api/v0/totals` and gives the same results.

Koios command: `curl -sL https://testnet.koios.rest/api/v0/totals | jq .[0]`
```json
{
  "epoch_no": 193,
  "circulation": "40108613070266897",
  "treasury": "201142519024751",
  "reward": "62678759391893",
  "supply": "40373226600586997",
  "reserves": "4626773399413003"
}
```

Testing command: `curl -sL http://localhost:8080/api/v0/totals | jq .[0]`
```json
{
  "epoch_no": 193,
  "circulation": "40108613070266897",
  "treasury": "201142519024751",
  "reward": "62678759391893",
  "supply": "40373226600586997",
  "reserves": "4626773399413003"
}
```

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>